### PR TITLE
upgrade bootstrap dependencies to 4.3.1

### DIFF
--- a/JSON AJAX/app.js
+++ b/JSON AJAX/app.js
@@ -47,7 +47,7 @@ function render(data){
             string+= data[i].foods.likes[j]+", ";
         }
     }
-    string += "</p>";
+        
 
     container.insertAdjacentHTML('beforeend', string);
 }

--- a/laravel/lsapp/package-lock.json
+++ b/laravel/lsapp/package-lock.json
@@ -1577,7 +1577,7 @@
             "dev": true
         },
         "bootstrap": {
-            "version": "4.2.1",
+            "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
             "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q==",
             "dev": true


### PR DESCRIPTION
Vulnerable versions: >= 4.0.0, < 4.3.1
Patched version: 4.3.1
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/