### PR TITLE
upgrade lodash dependencies to 4.17.13

### DIFF
--- a/laravel/lsapp/package-lock.json
+++ b/laravel/lsapp/package-lock.json
@@ -2409,7 +2409,7 @@
                 "css-selector-tokenizer": "^0.7.0",
                 "icss-utils": "^2.1.0",
                 "loader-utils": "^1.0.2",
-                "lodash": "^4.17.11",
+                "lodash": "4.17.13",
                 "postcss": "^6.0.23",
                 "postcss-modules-extract-imports": "^1.2.0",
                 "postcss-modules-local-by-default": "^1.2.0",


### PR DESCRIPTION
Vulnerable versions: < 4.17.13
Patched version: 4.17.13
Affected versions of lodash are vulnerable to Prototype Pollution.
The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.