### PR TITLE
update jquery dependencies version to 3.4.0

### DIFF
--- a/laravel/lsapp/package-lock.json
+++ b/laravel/lsapp/package-lock.json
@@ -5243,7 +5243,7 @@
             "dev": true
         },
         "jquery": {
-            "version": "3.3.1",
+            "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
             "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
             "dev": true


### PR DESCRIPTION
Vulnerable versions: < 3.4.0
Patched version: 3.4.0
jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable proto property, it could extend the native Object.prototype.